### PR TITLE
Use @netacea/cloudflare@6.6.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Netacea/Cloudflare Worker Template
+
 ## Summary
 
 <!-- What changed? -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@netacea/cloudflare": "^6.4.1"
+        "@netacea/cloudflare": "^6.6.2"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240821.1",
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@netacea/cloudflare": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@netacea/cloudflare/-/cloudflare-6.4.1.tgz",
-      "integrity": "sha512-vXIX5Tu4XG2r2ZOEzOSdI/vPS3nW+zO8k/Ui5/pxgFliUiAbcW3M2vAAFPV30di0RBERMDR6RIJcWyBTyOnM3w==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@netacea/cloudflare/-/cloudflare-6.6.2.tgz",
+      "integrity": "sha512-ZCLqoyaVwgBmWHJdB1qldgz9LXh7lYyF5/dlRoWPp1fEEWTdBt48HuGLtcQL5FrRyjmpeFtlAa2crvL1UxerqA==",
       "license": "ISC",
       "dependencies": {
         "aws4fetch": "^1.0.20",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "wrangler": "^4.77.0"
   },
   "dependencies": {
-    "@netacea/cloudflare": "^6.4.1"
+    "@netacea/cloudflare": "^6.6.2"
   }
 }


### PR DESCRIPTION
# Netacea/Cloudflare Worker Template

## Summary

- Bumped `@netacea/cloudflare` to `6.6.2`

## Checklist

- [x] NPM Audit issues addressed
  - No issues found. 
- [x] Migration guide included (if major version bump / breaking change)
  - Not a breaking change.
